### PR TITLE
chore: bump nexus-sdk/nexus-toolkit to v2.0.0-rc.1

### DIFF
--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -897,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "nexus-sdk"
 version = "1.0.0"
-source = "git+https://github.com/Talus-Network/nexus-sdk?tag=v1.0.0#56f32530d889e480004d167e323d957c01181821"
+source = "git+https://github.com/Talus-Network/nexus-sdk?rev=96ad467a15528ab50d74b591879bb7fb7e8f8c12#96ad467a15528ab50d74b591879bb7fb7e8f8c12"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "nexus-toolkit"
 version = "1.0.0"
-source = "git+https://github.com/Talus-Network/nexus-sdk?tag=v1.0.0#56f32530d889e480004d167e323d957c01181821"
+source = "git+https://github.com/Talus-Network/nexus-sdk?rev=96ad467a15528ab50d74b591879bb7fb7e8f8c12#96ad467a15528ab50d74b591879bb7fb7e8f8c12"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2861,7 +2861,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3231,7 +3231,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3290,7 +3290,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3905,7 +3905,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4654,7 +4654,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -897,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "nexus-sdk"
 version = "1.0.0"
-source = "git+https://github.com/Talus-Network/nexus-sdk?rev=96ad467a15528ab50d74b591879bb7fb7e8f8c12#96ad467a15528ab50d74b591879bb7fb7e8f8c12"
+source = "git+https://github.com/Talus-Network/nexus-sdk?tag=v2.0.0-rc.1#895b93251b5d5e9083b51c10a6965c38af51f6f7"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "nexus-toolkit"
 version = "1.0.0"
-source = "git+https://github.com/Talus-Network/nexus-sdk?rev=96ad467a15528ab50d74b591879bb7fb7e8f8c12#96ad467a15528ab50d74b591879bb7fb7e8f8c12"
+source = "git+https://github.com/Talus-Network/nexus-sdk?tag=v2.0.0-rc.1#895b93251b5d5e9083b51c10a6965c38af51f6f7"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2861,7 +2861,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3231,7 +3231,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3290,7 +3290,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3905,7 +3905,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4654,7 +4654,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/offchain/Cargo.toml
+++ b/offchain/Cargo.toml
@@ -49,13 +49,13 @@ features = ["full"]
 # For local dev convenience
 # path = "../../nexus-sdk/sdk"
 git = "https://github.com/Talus-Network/nexus-sdk"
-rev = "96ad467a15528ab50d74b591879bb7fb7e8f8c12"
+tag = "v2.0.0-rc.1"
 
 [workspace.dependencies.nexus-toolkit]
 # For local dev convenience
 # path = "../../nexus-sdk/toolkit-rust"
 git = "https://github.com/Talus-Network/nexus-sdk"
-rev = "96ad467a15528ab50d74b591879bb7fb7e8f8c12"
+tag = "v2.0.0-rc.1"
 
 
 [profile.release]

--- a/offchain/Cargo.toml
+++ b/offchain/Cargo.toml
@@ -49,13 +49,13 @@ features = ["full"]
 # For local dev convenience
 # path = "../../nexus-sdk/sdk"
 git = "https://github.com/Talus-Network/nexus-sdk"
-tag = "v1.0.0"
+rev = "96ad467a15528ab50d74b591879bb7fb7e8f8c12"
 
 [workspace.dependencies.nexus-toolkit]
 # For local dev convenience
 # path = "../../nexus-sdk/toolkit-rust"
 git = "https://github.com/Talus-Network/nexus-sdk"
-tag = "v1.0.0"
+rev = "96ad467a15528ab50d74b591879bb7fb7e8f8c12"
 
 
 [profile.release]


### PR DESCRIPTION
## Summary

Bumps `nexus-sdk` and `nexus-toolkit` in `offchain/Cargo.toml` from `tag = "v1.0.0"` to `tag = "v2.0.0-rc.1"` (commit `895b9325`) so the offchain tools speak the new signed-HTTP wire protocol that v2 leaders expect.

## Why this matters

The signed-HTTP wire protocol changed between `nexus-sdk@v1.0.0` and the v2.0.0 line. Specifically in [`sdk/src/signed_http/v1/wire.rs`](https://github.com/Talus-Network/nexus-sdk/blob/v2.0.0-rc.1/sdk/src/signed_http/v1/wire.rs):

- **Request signing message**: was `message_to_verify(DOMAIN_REQUEST_V1, &sig_input)`; now `request_signature_message_v1(&sha256(sig_input))` — different bytes signed.
- **Response signing message**: was `message_to_verify(DOMAIN_RESPONSE_V1, &sig_input)`; now `response_signature_message_v1(claimed_req_hash, body_hash, status, outcome)` — incorporates request hash, body hash, and a new outcome classification (`RESPONSE_OUTCOME_SUCCESS_V1`, `RESPONSE_OUTCOME_ERR_EVAL_V1`).
- `sign_invoke_response_v1` is now `#[deprecated]` in favor of `sign_invoke_response_with_body_v1`.

Without this bump, tools built from this repo return **HTTP 401** to v2 leaders (the signed request can't be verified by the old verifier). Confirmed in the workbench: same DAG that aborted with `terminal_tool_failure` before this change executes successfully after it.

## Deploy impact

Merging to `main` is safe in isolation — push-to-main fires only the `deploy` job (image build + push to GCR with `sha-<SHA>` tags). It does **not** fire `prepare`, `register`, or `trigger-tf-apply` (see `.github/workflows/ci.yml`). Live testnet / mainnet stays pinned to whatever the last `testnet-*` / `mainnet-*` tag put on chain.

The new v2 SDK only goes live when a v2-themed deploy track (new GitHub env + tag prefix + tf-talus-nexus-v2 namespace) explicitly targets it. That side-by-side wiring is separate from this PR.

## Scope

Workspace-level pin in `offchain/Cargo.toml`. All workspace members (`tools/*`) pick up the new SDK via `workspace = true` / `workspace.dependencies`:

- `math`, `storage-walrus`, `social-twitter`, `llm-openai-chat-completion`
- `http`, `memory-memwal`, `templating-jinja`, `exchanges-coinbase`

## Verification

- `cargo check --workspace` passes cleanly (only pre-existing dead-code warnings in `social-twitter`).
- Workbench end-to-end DAG (`math_branching`: `add → is_negative → mul_by_7`) returns `ok` against a v2 leader; previously aborted on first vertex with `tool response is missing signed_http headers`.

## Test plan

- [x] `cargo check --workspace` passes
- [x] Workbench builds `nexus-tools/math:<sha>` etc. images successfully
- [x] Workbench DAG execution returns `ok` end-to-end against v2 leader
