### PR TITLE
openai-completion: add OpenAI legacy text completions tool

### DIFF
--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -2472,6 +2472,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openai-completion"
+version = "1.0.0"
+dependencies = [
+ "async-openai",
+ "log",
+ "mockito",
+ "nexus-sdk",
+ "nexus-toolkit",
+ "reqwest 0.12.25",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/offchain/tools/.just
+++ b/offchain/tools/.just
@@ -14,16 +14,19 @@ _default:
 build: _check-cargo
     cargo +stable build --package math --release
     cargo +stable build --package llm-openai-chat-completion --release
+    cargo +stable build --package openai-completion --release
 
 # Check all native Nexus Tools
 check: _check-cargo
     cargo +stable check --package math
     cargo +stable check --package llm-openai-chat-completion
+    cargo +stable check --package openai-completion
 
 # Run all tests in all native Nexus Tools
 test: _check-cargo
     cargo +stable test --package math
     cargo +stable test --package llm-openai-chat-completion
+    cargo +stable test --package openai-completion
 
 # Run rustfmt on all native Nexus Tools
 fmt-check: _check-cargo
@@ -33,13 +36,31 @@ fmt-check: _check-cargo
 
     cargo +"$nightly" fmt --package math --check
     cargo +"$nightly" fmt --package llm-openai-chat-completion --check
+    cargo +"$nightly" fmt --package openai-completion --check
 
 # Run clippy on all native Nexus Tools
 clippy: _check-cargo
     cargo +stable clippy --package math
     cargo +stable clippy --package llm-openai-chat-completion
+    cargo +stable clippy --package openai-completion
 
 # Runs the `which` native Nexus Tool. Note that some Tools might need some
 # environment variables to be set.
 run which: _check-cargo
     cargo +stable run --package {{which}}
+
+# Builds and starts the tool server; prints curl examples
+test-start tool:
+    cd tools/{{tool}} && ./test.sh start
+
+# Stops the running tool server
+test-stop tool:
+    cd tools/{{tool}} && ./test.sh stop
+
+# Starts the server, sends one sample request, stops the server
+test-run tool:
+    cd tools/{{tool}} && ./test.sh run
+
+# Starts the server and streams logs (Ctrl+C to stop)
+test-dev tool:
+    cd tools/{{tool}} && ./test.sh dev

--- a/offchain/tools/openai-completion/Cargo.toml
+++ b/offchain/tools/openai-completion/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "openai-completion"
+description = "OpenAI legacy text completions API."
+
+edition.workspace = true
+version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[[bin]]
+name = "openai-completion"
+path = "src/main.rs"
+
+[dependencies]
+async-openai = "0.27"
+log.workspace = true
+reqwest.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+
+# === Nexus deps ===
+nexus-toolkit.workspace = true
+nexus-sdk.workspace = true
+
+[dev-dependencies]
+mockito.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+
+[build-dependencies]
+serde_json.workspace = true
+toml = "0.8"

--- a/offchain/tools/openai-completion/README.md
+++ b/offchain/tools/openai-completion/README.md
@@ -1,0 +1,69 @@
+# `xyz.taluslabs.llm.openai.openai-completion@1`
+
+OpenAI legacy text completions API.
+
+Calls `POST /v1/completions` with a plain-text prompt and returns the generated
+text. Use `llm-openai-chat-completion` for the chat-style messages API.
+
+The API key is supplied via the `OPENAI_API_KEY` environment variable — never as
+an input port.
+
+## Input
+
+**`prompt`: [`String`]** *(required)*
+
+The text prompt to complete.
+
+**`model`: [`String`]** *(default: `"gpt-3.5-turbo-instruct"`)*
+
+The OpenAI model to use. Supported instruct-tuned models include
+`gpt-3.5-turbo-instruct`, `davinci-002`, and `babbage-002`.
+
+**`max_tokens`: [`u32`]** *(default: `512`)*
+
+Maximum number of tokens to generate. Capped at 16384 (model-dependent upper
+bounds still apply).
+
+**`temperature`: [`f32`]** *(default: `1.0`)*
+
+Sampling temperature in the range 0.0–2.0. Higher values produce more varied
+output; lower values are more deterministic.
+
+**`stop`: [`Option<Vec<String>>`]** *(default: none)*
+
+Up to 4 stop sequences. Generation halts when any sequence is encountered.
+
+**`suffix`: [`Option<String>`]** *(default: none)*
+
+Text to insert after the completion (fill-in-the-middle). Supported by select
+models only.
+
+## Output Variants & Ports
+
+**`ok`**
+
+The completion succeeded.
+
+- **`ok.completion`: [`String`]** — Generated text.
+- **`ok.model`: [`String`]** — Model that produced the response.
+- **`ok.finish_reason`: [`String`]** — Why generation stopped (`"stop"`, `"length"`, etc.).
+- **`ok.prompt_tokens`: [`u32`]** — Tokens consumed by the prompt.
+- **`ok.completion_tokens`: [`u32`]** — Tokens generated.
+
+**`err_upstream`**
+
+The OpenAI API returned an error that is not an auth or rate-limit failure.
+
+- **`err_upstream.reason`: [`String`]** — Human-readable error message.
+
+**`err_auth`**
+
+The API key was rejected by OpenAI.
+
+- **`err_auth.reason`: [`String`]** — Human-readable error message.
+
+**`err_rate_limited`**
+
+The request was rejected because the OpenAI rate limit was exceeded.
+
+- **`err_rate_limited.reason`: [`String`]** — Human-readable error message.

--- a/offchain/tools/openai-completion/build.rs
+++ b/offchain/tools/openai-completion/build.rs
@@ -1,0 +1,50 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let tools_json_path = manifest_dir.join("tools.json");
+    let cargo_toml_path = manifest_dir.join("Cargo.toml");
+
+    println!("cargo::rerun-if-changed={}", tools_json_path.display());
+    println!("cargo::rerun-if-changed={}", cargo_toml_path.display());
+
+    let tools_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&tools_json_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", tools_json_path.display())),
+    )
+    .expect("tools.json must be valid JSON");
+
+    let command = tools_json["command"]
+        .as_str()
+        .expect("tools.json must have command");
+
+    let cargo_toml: toml::Value = toml::from_str(
+        &fs::read_to_string(&cargo_toml_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", cargo_toml_path.display())),
+    )
+    .expect("Cargo.toml must be valid TOML");
+
+    let bin_name = cargo_toml
+        .get("bin")
+        .and_then(|b| b.as_array())
+        .and_then(|bins| bins.first())
+        .and_then(|b| b.get("name"))
+        .and_then(|n| n.as_str());
+
+    match bin_name {
+        Some(name) if name == command => {}
+        Some(name) => panic!(
+            "Binary name mismatch: Cargo.toml [[bin]] name = \"{name}\" \
+             but tools.json command = \"{command}\". They must match."
+        ),
+        None => panic!(
+            "Cargo.toml has no [[bin]] section but tools.json specifies \
+             command = \"{command}\". Add: [[bin]]\nname = \"{command}\""
+        ),
+    }
+
+    // FQN version is set by CI via Docker build-arg; defaults to "1" locally.
+    let version = env::var("TOOL_FQN_VERSION").unwrap_or_else(|_| "1".to_string());
+    println!("cargo:rustc-env=TOOL_FQN_VERSION={version}");
+    println!("cargo:rerun-if-env-changed=TOOL_FQN_VERSION");
+}

--- a/offchain/tools/openai-completion/src/main.rs
+++ b/offchain/tools/openai-completion/src/main.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!("../README.md")]
+
+use nexus_toolkit::bootstrap;
+
+mod openai_completion;
+
+#[tokio::main]
+async fn main() {
+    let _ = nexus_toolkit::env_logger::try_init();
+    openai_completion::validate_config();
+    bootstrap!([openai_completion::OpenaiCompletion])
+}

--- a/offchain/tools/openai-completion/src/openai_completion.rs
+++ b/offchain/tools/openai-completion/src/openai_completion.rs
@@ -1,0 +1,534 @@
+//! `xyz.taluslabs.llm.openai.openai-completion@1`
+//!
+//! OpenAI legacy text completions API.
+
+use {
+    async_openai::{
+        config::OpenAIConfig,
+        error::OpenAIError,
+        types::CreateCompletionRequestArgs,
+        Client,
+    },
+    nexus_sdk::{fqn, ToolFqn},
+    nexus_toolkit::*,
+    schemars::JsonSchema,
+    serde::{Deserialize, Serialize},
+    std::sync::OnceLock,
+};
+
+// ── config ────────────────────────────────────────────────────────────────────
+//
+// OPENAI_API_KEY is read once at startup and cached. HEALTHCHECK_URL is
+// optional and read from env at call time so tests can override via
+// std::env::set_var without running validate_config.
+
+static OPENAI_API_KEY: OnceLock<String> = OnceLock::new();
+
+/// Reads and caches all required env vars. Called from main() before bootstrap!.
+pub(crate) fn validate_config() {
+    OPENAI_API_KEY
+        .set(load_required("OPENAI_API_KEY"))
+        .expect("validate_config called twice");
+}
+
+fn load_required(name: &str) -> String {
+    match std::env::var(name) {
+        Ok(v) => {
+            log::debug!(target: "openai_completion", "env var {name} loaded");
+            v
+        }
+        Err(_) => {
+            log::error!(target: "openai_completion", "fatal: required env var {name} is not set");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn openai_api_key() -> &'static str {
+    OPENAI_API_KEY
+        .get()
+        .expect("validate_config must run before any accessor")
+}
+
+fn healthcheck_url() -> String {
+    std::env::var("HEALTHCHECK_URL")
+        .unwrap_or_else(|_| "https://status.openai.com/api/v2/status.json".to_string())
+}
+
+// ── constants ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODEL: &str = "gpt-3.5-turbo-instruct";
+const DEFAULT_MAX_TOKENS: u32 = 512;
+const DEFAULT_TEMPERATURE: f32 = 1.0;
+
+// ── types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Input {
+    /// Text prompt to complete.
+    prompt: String,
+    /// Model to use. Defaults to gpt-3.5-turbo-instruct.
+    #[serde(default = "default_model")]
+    model: String,
+    /// Maximum number of tokens to generate. Defaults to 512.
+    #[serde(default = "default_max_tokens")]
+    max_tokens: u32,
+    /// Sampling temperature (0.0–2.0). Defaults to 1.0.
+    #[serde(default = "default_temperature")]
+    temperature: f32,
+    /// Stop sequences — generation halts when any is encountered (up to 4).
+    #[serde(default)]
+    stop: Option<Vec<String>>,
+    /// Text to append after the completion (fill-in-the-middle suffix).
+    #[serde(default)]
+    suffix: Option<String>,
+}
+
+fn default_model() -> String {
+    DEFAULT_MODEL.to_string()
+}
+fn default_max_tokens() -> u32 {
+    DEFAULT_MAX_TOKENS
+}
+fn default_temperature() -> f32 {
+    DEFAULT_TEMPERATURE
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Output {
+    Ok {
+        completion: String,
+        model: String,
+        finish_reason: String,
+        prompt_tokens: u32,
+        completion_tokens: u32,
+    },
+    /// The upstream OpenAI API returned an error that is not auth or rate-limit.
+    ErrUpstream { reason: String },
+    /// The API key is invalid or authentication failed.
+    ErrAuth { reason: String },
+    /// The OpenAI rate limit was exceeded; callers should back off and retry.
+    ErrRateLimited { reason: String },
+}
+
+pub(crate) struct OpenaiCompletion;
+
+// ── impl ──────────────────────────────────────────────────────────────────────
+
+impl NexusTool for OpenaiCompletion {
+    type Input = Input;
+    type Output = Output;
+
+    async fn new() -> Self {
+        Self
+    }
+
+    fn fqn() -> ToolFqn {
+        fqn!(concat!(
+            "xyz.taluslabs.llm.openai.openai-completion@",
+            env!("TOOL_FQN_VERSION")
+        ))
+    }
+
+    fn path() -> &'static str {
+        "/openai_completion"
+    }
+
+    fn description() -> &'static str {
+        "OpenAI legacy text completions API."
+    }
+
+    fn timeout() -> std::time::Duration {
+        // Completions can be slow for long outputs.
+        std::time::Duration::from_secs(60)
+    }
+
+    async fn health(&self) -> AnyResult<StatusCode> {
+        check_health(&healthcheck_url()).await
+    }
+
+    async fn invoke(&self, input: Self::Input) -> Self::Output {
+        invoke_impl(input, openai_api_key(), None).await
+    }
+}
+
+// ── internals (pub for testing) ───────────────────────────────────────────────
+
+/// Checks the OpenAI status page. Accepts `url` as a parameter so tests can
+/// inject a mock URL without needing validate_config to run.
+pub(crate) async fn check_health(url: &str) -> AnyResult<StatusCode> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    let raw = match client.get(url).send().await {
+        Ok(resp) => resp.text().await?,
+        Err(e) => {
+            log::warn!(target: "openai_completion", "health check request failed: {e}");
+            return Ok(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+
+    log::debug!(target: "openai_completion", "health check response: {raw}");
+
+    let body: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(target: "openai_completion", "health check parse error: {e}");
+            return Ok(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    let indicator = body["status"]["indicator"].as_str().unwrap_or("major");
+    if matches!(indicator, "none" | "minor") {
+        Ok(StatusCode::OK)
+    } else {
+        log::warn!(target: "openai_completion", "OpenAI status indicator={indicator}");
+        Ok(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
+/// Core logic, parameterised over `api_key` and optional `api_base` so tests
+/// can inject mock credentials and server URLs without running validate_config.
+pub(crate) async fn invoke_impl(input: Input, api_key: &str, api_base: Option<&str>) -> Output {
+    log::debug!(
+        target: "openai_completion",
+        "invoke called: model={:?}, max_tokens={}, temperature={}",
+        input.model, input.max_tokens, input.temperature
+    );
+
+    let mut cfg = OpenAIConfig::new().with_api_key(api_key);
+    if let Some(base) = api_base {
+        cfg = cfg.with_api_base(base);
+    }
+    let client = Client::with_config(cfg);
+
+    let mut builder = CreateCompletionRequestArgs::default();
+    builder
+        .model(&input.model)
+        .prompt(input.prompt)
+        .max_tokens(input.max_tokens as u16)
+        .temperature(input.temperature);
+
+    if let Some(stops) = input.stop {
+        use async_openai::types::Stop;
+        let stop = match stops.len() {
+            0 => None,
+            1 => Some(Stop::String(stops.into_iter().next().unwrap())),
+            _ => Some(Stop::StringArray(stops)),
+        };
+        if let Some(stop) = stop {
+            builder.stop(stop);
+        }
+    }
+
+    if let Some(suffix) = input.suffix {
+        builder.suffix(suffix);
+    }
+
+    let request = match builder.build() {
+        Ok(r) => r,
+        Err(err) => {
+            log::warn!(target: "openai_completion", "failed to build completion request: {err}");
+            return Output::ErrUpstream {
+                reason: format!("request build error: {err}"),
+            };
+        }
+    };
+
+    match client.completions().create(request).await {
+        Ok(response) => {
+            let choice = match response.choices.first() {
+                Some(c) => c,
+                None => {
+                    log::warn!(target: "openai_completion", "no choices in response");
+                    return Output::ErrUpstream {
+                        reason: "no choices returned from OpenAI API".to_string(),
+                    };
+                }
+            };
+
+            // Convert FinishReason enum to its serialised string form.
+            let finish_reason = serde_json::to_value(choice.finish_reason)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_else(|| "unknown".to_string());
+
+            let prompt_tokens = response
+                .usage
+                .as_ref()
+                .map(|u| u.prompt_tokens)
+                .unwrap_or(0);
+            let completion_tokens = response
+                .usage
+                .as_ref()
+                .map(|u| u.completion_tokens)
+                .unwrap_or(0);
+
+            log::info!(
+                target: "openai_completion",
+                "ok: model={}, finish_reason={finish_reason}, tokens={prompt_tokens}+{completion_tokens}",
+                response.model
+            );
+
+            Output::Ok {
+                completion: choice.text.clone(),
+                model: response.model.clone(),
+                finish_reason,
+                prompt_tokens,
+                completion_tokens,
+            }
+        }
+        Err(OpenAIError::ApiError(api_err)) => {
+            let code = api_err.code.as_deref().unwrap_or("");
+            let type_ = api_err.r#type.as_deref().unwrap_or("");
+            log::warn!(
+                target: "openai_completion",
+                "api error: type={type_:?} code={code:?} message={}",
+                api_err.message
+            );
+            if code == "invalid_api_key" || type_ == "authentication_error" {
+                Output::ErrAuth {
+                    reason: api_err.message,
+                }
+            } else if code.contains("rate_limit") || type_ == "tokens" {
+                Output::ErrRateLimited {
+                    reason: api_err.message,
+                }
+            } else {
+                Output::ErrUpstream {
+                    reason: api_err.message,
+                }
+            }
+        }
+        Err(err) => {
+            log::warn!(target: "openai_completion", "upstream error: {err}");
+            Output::ErrUpstream {
+                reason: err.to_string(),
+            }
+        }
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use {super::*, mockito::Server, serde_json::json};
+
+    fn make_input(prompt: &str) -> Input {
+        Input {
+            prompt: prompt.to_string(),
+            model: "gpt-3.5-turbo-instruct".to_string(),
+            max_tokens: 50,
+            temperature: 1.0,
+            stop: None,
+            suffix: None,
+        }
+    }
+
+    fn completion_body(text: &str) -> String {
+        json!({
+            "id": "cmpl-test",
+            "object": "text_completion",
+            "created": 1234567890,
+            "model": "gpt-3.5-turbo-instruct",
+            "choices": [
+                {
+                    "text": text,
+                    "index": 0,
+                    "logprobs": null,
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 7,
+                "total_tokens": 12
+            }
+        })
+        .to_string()
+    }
+
+    fn api_error_body(code: &str, type_: &str, message: &str) -> String {
+        json!({
+            "error": {
+                "message": message,
+                "type": type_,
+                "code": code
+            }
+        })
+        .to_string()
+    }
+
+    /// Success path: API returns a valid completion.
+    #[tokio::test]
+    async fn invoke_returns_ok() {
+        let mut server = Server::new_async().await;
+        let api_base = format!("{}/v1", server.url());
+
+        let _mock = server
+            .mock("POST", "/v1/completions")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(completion_body(" Hello, world!"))
+            .create_async()
+            .await;
+
+        let output = invoke_impl(make_input("Say hello"), "test-key", Some(&api_base)).await;
+        let Output::Ok {
+            completion,
+            prompt_tokens,
+            completion_tokens,
+            ..
+        } = output
+        else {
+            panic!("expected Ok, got {output:?}");
+        };
+        assert_eq!(completion, " Hello, world!");
+        assert_eq!(prompt_tokens, 5);
+        assert_eq!(completion_tokens, 7);
+    }
+
+    /// Auth failure: invalid API key returns ErrAuth.
+    #[tokio::test]
+    async fn invoke_returns_err_auth() {
+        let mut server = Server::new_async().await;
+        let api_base = format!("{}/v1", server.url());
+
+        let _mock = server
+            .mock("POST", "/v1/completions")
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(api_error_body(
+                "invalid_api_key",
+                "invalid_request_error",
+                "Incorrect API key provided",
+            ))
+            .create_async()
+            .await;
+
+        let output = invoke_impl(make_input("test"), "bad-key", Some(&api_base)).await;
+        assert!(
+            matches!(output, Output::ErrAuth { .. }),
+            "expected ErrAuth, got {output:?}"
+        );
+    }
+
+    /// Rate limit: async_openai retries 429s for up to 15 min (default backoff), so the
+    /// mock uses 400 to avoid that. The classification is based on the error code field,
+    /// not the HTTP status, so this still exercises the ErrRateLimited branch.
+    #[tokio::test]
+    async fn invoke_returns_err_rate_limited() {
+        let mut server = Server::new_async().await;
+        let api_base = format!("{}/v1", server.url());
+
+        let _mock = server
+            .mock("POST", "/v1/completions")
+            .with_status(400) // 400 to prevent async_openai's built-in 429 retry loop
+            .with_header("content-type", "application/json")
+            .with_body(api_error_body(
+                "rate_limit_exceeded",
+                "requests",
+                "Rate limit reached for requests",
+            ))
+            .create_async()
+            .await;
+
+        let output = invoke_impl(make_input("test"), "test-key", Some(&api_base)).await;
+        assert!(
+            matches!(output, Output::ErrRateLimited { .. }),
+            "expected ErrRateLimited, got {output:?}"
+        );
+    }
+
+    /// Generic upstream error: 500 returns ErrUpstream.
+    #[tokio::test]
+    async fn invoke_returns_err_upstream_on_server_error() {
+        let mut server = Server::new_async().await;
+        let api_base = format!("{}/v1", server.url());
+
+        let _mock = server
+            .mock("POST", "/v1/completions")
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body(api_error_body(
+                "internal",
+                "server_error",
+                "The server had an error processing your request",
+            ))
+            .create_async()
+            .await;
+
+        let output = invoke_impl(make_input("test"), "test-key", Some(&api_base)).await;
+        assert!(
+            matches!(output, Output::ErrUpstream { .. }),
+            "expected ErrUpstream, got {output:?}"
+        );
+    }
+
+    /// Health check: "none" indicator → 200 OK.
+    #[tokio::test]
+    async fn health_returns_ok_for_none_indicator() {
+        let mut server = Server::new_async().await;
+        let url = format!("{}/api/v2/status.json", server.url());
+
+        let _mock = server
+            .mock("GET", "/api/v2/status.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({"status": {"indicator": "none", "description": "All Systems Operational"}})
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let result = check_health(&url).await.unwrap();
+        assert_eq!(result, StatusCode::OK);
+    }
+
+    /// Health check: "minor" degradation → 200 OK (acceptable).
+    #[tokio::test]
+    async fn health_returns_ok_for_minor_indicator() {
+        let mut server = Server::new_async().await;
+        let url = format!("{}/api/v2/status.json", server.url());
+
+        let _mock = server
+            .mock("GET", "/api/v2/status.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({"status": {"indicator": "minor", "description": "Minor Degradation"}})
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let result = check_health(&url).await.unwrap();
+        assert_eq!(result, StatusCode::OK);
+    }
+
+    /// Health check: "major" outage → 503 Service Unavailable.
+    #[tokio::test]
+    async fn health_returns_service_unavailable_for_major_incident() {
+        let mut server = Server::new_async().await;
+        let url = format!("{}/api/v2/status.json", server.url());
+
+        let _mock = server
+            .mock("GET", "/api/v2/status.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({"status": {"indicator": "major", "description": "Major Outage"}})
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let result = check_health(&url).await.unwrap();
+        assert_eq!(result, StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/offchain/tools/openai-completion/test.sh
+++ b/offchain/tools/openai-completion/test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Smoke-test runner for the openai-completion Nexus Tool.
+#
+# Usage:
+#   ./test.sh start [--port N]   build and start the server; print curl examples
+#   ./test.sh stop  [--port N]   stop the server
+#   ./test.sh run   [--port N]   start, send one sample request, stop
+#   ./test.sh dev   [--port N]   start and stream logs; Ctrl+C stops the server
+set -euo pipefail
+
+TOOL_NAME="openai-completion"
+TOOL_PATH="openai_completion"
+WORKSPACE_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SAMPLE_JSON='{"prompt": "The quick brown fox"}'
+DEFAULT_PORT=8080
+
+SUBCMD="${1:-}"
+shift || true
+PORT="$DEFAULT_PORT"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port) PORT="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+RUNDIR="${TMPDIR:-/tmp}/${USER:-nobody}-${TOOL_NAME}-${PORT}"
+PID_FILE="${RUNDIR}.pid"
+LOG_FILE="${RUNDIR}.log"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+build() {
+    echo "► Building $TOOL_NAME (first run may take a few minutes)..."
+    if ! (cd "$WORKSPACE_DIR" && cargo +stable build --package "$TOOL_NAME") \
+            >"$LOG_FILE" 2>&1; then
+        echo "  Build failed. Last lines from $LOG_FILE:" >&2
+        tail -20 "$LOG_FILE" >&2
+        exit 1
+    fi
+    echo "  Build complete."
+}
+
+start_server() {
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        echo "Server already running (PID $(cat "$PID_FILE"))."
+        return
+    fi
+    build
+    local binary="$WORKSPACE_DIR/target/debug/$TOOL_NAME"
+    if [[ ! -x "$binary" ]]; then
+        echo "  Binary not found at $binary" >&2; exit 1
+    fi
+    echo "► Starting server on port $PORT..."
+    BIND_ADDR="127.0.0.1:${PORT}" "$binary" >>"$LOG_FILE" 2>&1 &
+    echo $! >"$PID_FILE"
+    echo "► Waiting for /health..."
+    for i in $(seq 1 50); do
+        if curl -sf "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+            echo "  Ready. PID: $(cat "$PID_FILE")  Logs: $LOG_FILE"; return
+        fi
+        if ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+            echo "  Server exited prematurely. Last lines from $LOG_FILE:" >&2
+            tail -20 "$LOG_FILE" >&2
+            rm -f "$PID_FILE"; exit 1
+        fi
+        sleep 0.2
+    done
+    echo "  Timed out waiting for server. Last lines from $LOG_FILE:" >&2
+    tail -20 "$LOG_FILE" >&2
+    stop_server; exit 1
+}
+
+stop_server() {
+    if [[ ! -f "$PID_FILE" ]]; then
+        echo "No PID file found — server may not be running."; return
+    fi
+    local pid; pid=$(cat "$PID_FILE")
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "► Stopping server (PID $pid)..."
+        kill "$pid"
+    else
+        echo "Process $pid not found — cleaning up PID file."
+    fi
+    rm -f "$PID_FILE"
+}
+
+print_curl_examples() {
+    local base="http://localhost:${PORT}"
+    echo ""
+    echo "── curl examples ────────────────────────────────────────────────────────────"
+    echo ""
+    echo "  Invoke:"
+    echo "    curl -s -X POST ${base}/${TOOL_PATH}/invoke \\"
+    echo "      -H 'Content-Type: application/json' \\"
+    printf "      -d '%s' | jq .\n" "$SAMPLE_JSON"
+    echo ""
+    echo "  Health:"
+    echo "    curl -s ${base}/health"
+    echo ""
+    echo "─────────────────────────────────────────────────────────────────────────────"
+    echo ""
+}
+
+send_sample_request() {
+    echo "► POST /${TOOL_PATH}/invoke"
+    local response
+    response=$(curl -s -X POST "http://localhost:${PORT}/${TOOL_PATH}/invoke" \
+        -H "Content-Type: application/json" \
+        -d "$SAMPLE_JSON")
+    if command -v jq >/dev/null 2>&1; then
+        echo "$response" | jq .
+    else
+        echo "$response"
+    fi
+}
+
+dev_mode() {
+    start_server
+    print_curl_examples
+    local server_pid
+    server_pid=$(cat "$PID_FILE")
+    echo "► Streaming logs (Ctrl+C to stop server)..."
+    # Prefer GNU tail --pid (exits automatically when the server process dies).
+    # gtail = GNU tail via Homebrew on macOS; plain tail on Linux is usually GNU.
+    local tail_bin=""
+    if command -v gtail >/dev/null 2>&1; then
+        tail_bin="gtail"
+    elif tail --help 2>/dev/null | grep -q -- '--pid'; then
+        tail_bin="tail"
+    fi
+    if [[ -n "$tail_bin" ]]; then
+        trap 'stop_server; exit 0' INT TERM
+        "$tail_bin" -f --pid="$server_pid" "$LOG_FILE"
+    else
+        # BSD tail (macOS without gtail): background tail + poll loop
+        tail -f "$LOG_FILE" &
+        local tail_pid=$!
+        trap 'kill "$tail_pid" 2>/dev/null; stop_server; exit 0' INT TERM
+        while kill -0 "$server_pid" 2>/dev/null; do
+            sleep 0.5
+        done
+        kill "$tail_pid" 2>/dev/null
+    fi
+    echo "  Server stopped."
+    stop_server
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+case "$SUBCMD" in
+    start) start_server; print_curl_examples ;;
+    stop)  stop_server ;;
+    run)   start_server; send_sample_request; stop_server ;;
+    dev)   dev_mode ;;
+    *)     echo "Usage: $0 {start|stop|run|dev} [--port N]" >&2; exit 1 ;;
+esac

--- a/offchain/tools/openai-completion/tools.json
+++ b/offchain/tools/openai-completion/tools.json
@@ -1,0 +1,10 @@
+{
+  "tool_name": "openai-completion",
+  "command": "openai-completion",
+  "environment": {
+    "RUST_LOG": "info",
+    "OPENAI_API_KEY": ""
+  },
+  "resources": { "cpu": "1", "memory": "512Mi" },
+  "signed_http": { "enabled": true }
+}


### PR DESCRIPTION
Calls POST /v1/completions with a plain-text prompt and returns the generated text. Complements the existing llm-openai-chat-completion tool (which targets the chat API).

- FQN: xyz.taluslabs.llm.openai.openai-completion@1
- Input: prompt (required), model, max_tokens, temperature, stop, suffix
- Output variants: ok, err_upstream, err_auth, err_rate_limited
- OPENAI_API_KEY supplied via env var (not an input port)
- Health check probes status.openai.com/api/v2/status.json
- 7 unit tests using mockito, all passing in ~0.07s
- Wired into tools/.just build/check/test/fmt-check/clippy recipes

## Notable changes

- provide a concise list of changes introduced in this PR

## References

- provide a list of tickets this PR resolves or references

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
