### PR TITLE
ci: split SUI_NETWORK + add v2.0.0-rc.1 RC deploy track

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,15 +213,7 @@ jobs:
   # GH_ACCESS_TOKEN PAT because GITHUB_TOKEN can't dispatch in other repos.
   trigger-tf-apply:
     needs: [register]
-    # tf-apply is gated off for the nexus-testnet-v2-0-rc-1 env while we
-    # bootstrap the new track. CI on this iterate branch should populate the
-    # GCS prefix and on-chain registrations; the tf-nexus-tools side is
-    # iterated manually until the namespace lands cleanly there. Once that's
-    # stable, drop the two `startsWith` exclusions to re-enable auto-apply.
-    if: >-
-      always() && !cancelled() && needs.register.result == 'success' &&
-      !startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/') &&
-      !startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-')
+    if: always() && !cancelled() && needs.register.result == 'success'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
           - ''
           - testnet
           - mainnet
+          - nexus-testnet-v2-0-rc-1
   pull_request:
     types: [opened, synchronize, reopened]
   push:
@@ -23,9 +24,11 @@ on:
       - main
       - 'iterate/testnet/**'
       - 'iterate/mainnet/**'
+      - 'iterate/nexus-testnet-v2-0-rc-1/**'
     # Tag-driven deploy. The tag prefix selects the env:
-    #   testnet-*  →  full pipeline against testnet
-    #   mainnet-*  →  full pipeline against mainnet
+    #   testnet-*                    →  full pipeline against testnet
+    #   mainnet-*                    →  full pipeline against mainnet
+    #   nexus-testnet-v2-0-rc-1-*    →  full pipeline against the v2 RC env
     # Tags are immutable per the convention, so each release-style
     # promotion lands on a specific commit and the deploy run is
     # attributable to that exact ref. No merge-strategy gotchas, no
@@ -34,6 +37,7 @@ on:
     tags:
       - 'testnet-*'
       - 'mainnet-*'
+      - 'nexus-testnet-v2-0-rc-1-*'
 
 permissions:
   contents: write
@@ -51,6 +55,7 @@ permissions:
 concurrency:
   group: >-
     ${{
+      (startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-') || startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/')) && 'chain-nexus-testnet-v2-0-rc-1' ||
       (startsWith(github.ref_name, 'mainnet-') || startsWith(github.ref_name, 'iterate/mainnet/')) && 'chain-mainnet' ||
       (startsWith(github.ref_name, 'testnet-') || startsWith(github.ref_name, 'iterate/testnet/')) && 'chain-testnet' ||
       (github.event_name == 'workflow_dispatch' && inputs.target-env != '') && format('chain-{0}', inputs.target-env) ||
@@ -111,8 +116,10 @@ jobs:
         ${{
           needs.resolve-target.outputs.base-ref ||
           inputs.target-env ||
+          (github.ref_type == 'tag' && startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-') && 'nexus-testnet-v2-0-rc-1') ||
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'mainnet-') && 'mainnet') ||
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'testnet-') && 'testnet') ||
+          (startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/') && 'nexus-testnet-v2-0-rc-1') ||
           (startsWith(github.ref_name, 'iterate/mainnet/') && 'mainnet') ||
           (startsWith(github.ref_name, 'iterate/testnet/') && 'testnet') ||
           (github.event_name == 'pull_request' && github.base_ref) ||
@@ -139,11 +146,13 @@ jobs:
       ((github.event_name == 'workflow_dispatch' && (inputs.pr-number != '' || inputs.target-env != '')) ||
        (github.event_name == 'push' && github.ref_type == 'branch' && (
          startsWith(github.ref_name, 'iterate/testnet/') ||
-         startsWith(github.ref_name, 'iterate/mainnet/')
+         startsWith(github.ref_name, 'iterate/mainnet/') ||
+         startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/')
        )) ||
        (github.event_name == 'push' && github.ref_type == 'tag' && (
          startsWith(github.ref_name, 'testnet-') ||
-         startsWith(github.ref_name, 'mainnet-')
+         startsWith(github.ref_name, 'mainnet-') ||
+         startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-')
        )))
     uses: ./.github/workflows/offchain-tools.prepare.yml
     with:
@@ -151,8 +160,10 @@ jobs:
         ${{
           needs.resolve-target.outputs.base-ref ||
           inputs.target-env ||
+          (github.ref_type == 'tag' && startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-') && 'nexus-testnet-v2-0-rc-1') ||
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'mainnet-') && 'mainnet') ||
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'testnet-') && 'testnet') ||
+          (startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/') && 'nexus-testnet-v2-0-rc-1') ||
           (startsWith(github.ref_name, 'iterate/mainnet/') && 'mainnet') ||
           (startsWith(github.ref_name, 'iterate/testnet/') && 'testnet') ||
           (github.event_name == 'pull_request' && github.base_ref) ||
@@ -171,8 +182,10 @@ jobs:
         ${{
           needs.resolve-target.outputs.base-ref ||
           inputs.target-env ||
+          (github.ref_type == 'tag' && startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-') && 'nexus-testnet-v2-0-rc-1') ||
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'mainnet-') && 'mainnet') ||
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'testnet-') && 'testnet') ||
+          (startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/') && 'nexus-testnet-v2-0-rc-1') ||
           (startsWith(github.ref_name, 'iterate/mainnet/') && 'mainnet') ||
           (startsWith(github.ref_name, 'iterate/testnet/') && 'testnet') ||
           (github.event_name == 'pull_request' && github.base_ref) ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,15 @@ jobs:
   # GH_ACCESS_TOKEN PAT because GITHUB_TOKEN can't dispatch in other repos.
   trigger-tf-apply:
     needs: [register]
-    if: always() && !cancelled() && needs.register.result == 'success'
+    # tf-apply is gated off for the nexus-testnet-v2-0-rc-1 env while we
+    # bootstrap the new track. CI on this iterate branch should populate the
+    # GCS prefix and on-chain registrations; the tf-nexus-tools side is
+    # iterated manually until the namespace lands cleanly there. Once that's
+    # stable, drop the two `startsWith` exclusions to re-enable auto-apply.
+    if: >-
+      always() && !cancelled() && needs.register.result == 'success' &&
+      !startsWith(github.ref_name, 'iterate/nexus-testnet-v2-0-rc-1/') &&
+      !startsWith(github.ref_name, 'nexus-testnet-v2-0-rc-1-')
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/offchain-tools.deploy.yml
+++ b/.github/workflows/offchain-tools.deploy.yml
@@ -26,6 +26,7 @@ jobs:
     environment: >-
       ${{
         (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'mainnet' && 'mainnet' ||
+        (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'nexus-testnet-v2-0-rc-1' && 'nexus-testnet-v2-0-rc-1' ||
         'testnet'
       }}
     strategy:

--- a/.github/workflows/offchain-tools.prepare.yml
+++ b/.github/workflows/offchain-tools.prepare.yml
@@ -22,6 +22,7 @@ jobs:
     environment: >-
       ${{
         (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'mainnet' && 'mainnet' ||
+        (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'nexus-testnet-v2-0-rc-1' && 'nexus-testnet-v2-0-rc-1' ||
         'testnet'
       }}
     strategy:
@@ -79,13 +80,30 @@ jobs:
           # whichever nexus version was current when it was first prepared.
           # Future NEXUS_TAG bumps only affect NEW deployments; existing
           # services keep their original allowed-leaders mount path.
+          # TOOLS_NAMESPACE (the deploy namespace — used for Cloud Run service
+          # naming, on-chain registration namespace, and GCS prefix) falls back
+          # to SUI_NETWORK on existing testnet/mainnet envs where they happen to
+          # be the same string. New envs (e.g. the v2 RC) set TOOLS_NAMESPACE
+          # explicitly so the namespace can be decoupled from chain_id.
+          TOOLS_NAMESPACE="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
+          # When TOOLS_NAMESPACE is set explicitly (i.e. differs from
+          # SUI_NETWORK), pin the allowed-leaders mount subdir to the upstream
+          # publish path directly. tf-nexus-tools' default derivation
+          # (`nexus-<chain_id>-<major.minor>`) only matches the v0.x convention;
+          # v2 uses the full RC suffix as the namespace directory name.
+          if [ "${{ vars.TOOLS_NAMESPACE }}" != "" ] && [ "${{ vars.TOOLS_NAMESPACE }}" != "${{ vars.SUI_NETWORK }}" ]; then
+            ALLOWED_LEADERS_SUBDIR="${{ vars.NEXUS_TAG }}/${{ vars.TOOLS_NAMESPACE }}"
+          else
+            ALLOWED_LEADERS_SUBDIR=""
+          fi
           jq -n \
             --arg name "$VERSIONED" \
-            --arg network "${{ vars.SUI_NETWORK }}" \
+            --arg network "$TOOLS_NAMESPACE" \
             --arg image "nexus-tools/${{ matrix.tool }}" \
             --arg tag "sha-${{ steps.names.outputs.sha }}" \
             --arg cmd "${{ matrix.command }}" \
             --arg nexus_tag "${{ vars.NEXUS_TAG }}" \
+            --arg allowed_leaders_subdir "$ALLOWED_LEADERS_SUBDIR" \
             --argjson extra_env "$EXTRA_ENV" \
             --argjson resources "$RESOURCES" \
             '{
@@ -104,7 +122,7 @@ jobs:
               ports: [{containerPort: 8080}],
               signed_http: {enabled: true},
               resources: $resources
-            }' > "$DIR/${VERSIONED}.json"
+            } + ($allowed_leaders_subdir | if . != "" then {allowed_leaders_subdir: .} else {} end)' > "$DIR/${VERSIONED}.json"
           echo "config=$DIR/${VERSIONED}.json" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GCP (protocol)
@@ -161,7 +179,7 @@ jobs:
         run: |
           set -euo pipefail
           BUCKET="${{ vars.GCP_PROJECT_ID }}-nexus-tools"
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
           VERSIONED="${{ steps.names.outputs.versioned }}"
           LOCAL="${{ steps.render.outputs.config }}"
           REMOTE="gs://${BUCKET}/${NETWORK}/offchain/tools/${VERSIONED}.json"
@@ -199,6 +217,7 @@ jobs:
     environment: >-
       ${{
         (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'mainnet' && 'mainnet' ||
+        (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'nexus-testnet-v2-0-rc-1' && 'nexus-testnet-v2-0-rc-1' ||
         'testnet'
       }}
     steps:
@@ -244,7 +263,7 @@ jobs:
         run: |
           set -euo pipefail
           BUCKET="${{ vars.GCP_PROJECT_ID }}-nexus-tools"
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
           HASH="${{ steps.manifest.outputs.hash }}"
           REMOTE="gs://${BUCKET}/${NETWORK}/offchain/manifest/${HASH}.json"
           if gsutil -q stat "$REMOTE" 2>/dev/null; then

--- a/.github/workflows/offchain-tools.readiness.yml
+++ b/.github/workflows/offchain-tools.readiness.yml
@@ -18,6 +18,7 @@ jobs:
     environment: >-
       ${{
         (github.base_ref || github.ref_name) == 'mainnet' && 'mainnet' ||
+        (github.base_ref || github.ref_name) == 'nexus-testnet-v2-0-rc-1' && 'nexus-testnet-v2-0-rc-1' ||
         'testnet'
       }}
     strategy:
@@ -39,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           BUCKET="${{ vars.GCP_PROJECT_ID }}-nexus-tools"
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
           TOOL="${{ matrix.tool }}"
           VERSION="${{ matrix.version }}"
           VERSIONED="${TOOL}-v${VERSION}"

--- a/.github/workflows/offchain-tools.register.yml
+++ b/.github/workflows/offchain-tools.register.yml
@@ -18,6 +18,7 @@ jobs:
     environment: >-
       ${{
         (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'mainnet' && 'mainnet' ||
+        (inputs.target-ref || github.event_name == 'pull_request' && github.base_ref || github.ref_name) == 'nexus-testnet-v2-0-rc-1' && 'nexus-testnet-v2-0-rc-1' ||
         'testnet'
       }}
     steps:
@@ -82,14 +83,19 @@ jobs:
           KEY_INDEX=$(sui keytool list --json | jq -r --arg addr "$ADDR" 'to_entries[] | select(.value.suiAddress == $addr) | .key')
           SUI_PK=$(jq -r --argjson idx "$KEY_INDEX" '.[$idx]' "$HOME/.sui/sui_config/sui.keystore")
 
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          # CHAIN_ID drives objects.toml filename and local nexus config —
+          # the file is published by tf-talus-nexus-v2 as
+          # objects.<chain_id>.toml (chain_id is testnet/mainnet). This stays
+          # tied to SUI_NETWORK; see TOOLS_NAMESPACE below for the deploy
+          # namespace, which is independent on the v2 RC env.
+          CHAIN_ID="${{ vars.SUI_NETWORK }}"
           wget -q -O "$RUNNER_TEMP/objects.toml" \
-            "https://storage.googleapis.com/production-talus-sui-objects/${{ vars.NEXUS_TAG }}/objects.${NETWORK}.toml?t=$(date +%s)"
+            "https://storage.googleapis.com/production-talus-sui-objects/${{ vars.NEXUS_TAG }}/objects.${CHAIN_ID}.toml?t=$(date +%s)"
 
           mkdir -p "$HOME/.nexus"
-          cp "$RUNNER_TEMP/objects.toml" "$HOME/.nexus/objects.${NETWORK}.toml"
+          cp "$RUNNER_TEMP/objects.toml" "$HOME/.nexus/objects.${CHAIN_ID}.toml"
           nexus conf set \
-            --nexus.objects "$HOME/.nexus/objects.${NETWORK}.toml" \
+            --nexus.objects "$HOME/.nexus/objects.${CHAIN_ID}.toml" \
             --sui.rpc-url "${{ vars.NEXT_PUBLIC_SUI_RPC_URL }}" \
             --sui.pk "$SUI_PK"
 
@@ -137,7 +143,10 @@ jobs:
           MANIFEST="${{ steps.artifacts.outputs.manifest }}"
           META_DIR="${{ steps.artifacts.outputs.meta_dir }}"
           BUCKET="${{ vars.GCP_PROJECT_ID }}-nexus-tools"
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          # NETWORK here is the deploy namespace — Cloud Run hostname stem,
+          # GCS prefix for registration blobs, on-chain registration namespace.
+          # Falls back to SUI_NETWORK on existing testnet/mainnet envs.
+          NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
 
           # Snapshot already-registered FQNs once up front. Each
           # `nexus tool register` call costs ~1-2s even for an
@@ -327,7 +336,7 @@ jobs:
           META_DIR="${{ steps.artifacts.outputs.meta_dir }}"
           PROJECT="${{ vars.GCP_PROJECT_ID }}"
           BUCKET="${{ vars.GCP_PROJECT_ID }}-nexus-tools"
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
 
           for TOOL in $(jq -r 'keys[]' "$MANIFEST"); do
             VERSION=$(jq -r --arg t "$TOOL" '.[$t].version' "$MANIFEST")
@@ -371,7 +380,7 @@ jobs:
           META_DIR="${{ steps.artifacts.outputs.meta_dir }}"
           PROJECT="${{ vars.GCP_PROJECT_ID }}"
           BUCKET="${{ vars.GCP_PROJECT_ID }}-nexus-tools"
-          NETWORK="${{ vars.SUI_NETWORK }}"
+          NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
 
           for TOOL in $(jq -r 'keys[]' "$MANIFEST"); do
             VERSION=$(jq -r --arg t "$TOOL" '.[$t].version' "$MANIFEST")


### PR DESCRIPTION
## Summary

Splits the overloaded `SUI_NETWORK` env var into two and adds the CI plumbing for a side-by-side v2.0.0-rc.1 RC deploy track. Activation is fully gated on creating the new GitHub environment + secrets (no behavior change on testnet/mainnet until then).

## Why

`SUI_NETWORK` was carrying two distinct semantics that happened to collapse to the same string on testnet/mainnet:

| Role | Where | Current value (testnet) |
|-|-|-|
| **chain_id** — used in `objects.<chain_id>.toml` filename, `~/.nexus/objects.<chain_id>.toml`, `nexus conf set` | `register.yml:85-95` | `testnet` |
| **deploy namespace** — Cloud Run service name stem, GCS prefix for tool/registration blobs, on-chain registration namespace | `prepare.yml:84,164,266`, `register.yml:140,330,374`, `readiness.yml:42` | `testnet` |

For the v2.0.0-rc.1 side-by-side rollout, the two diverge: the RC lives on the testnet **chain** (so the objects.toml file is `objects.testnet.toml` at the upstream publisher), but the **namespace** must be `nexus-testnet-v2-0-rc-1` so on-chain registrations, Cloud Run hostnames, and GCS prefixes don't collide with the live v0.8 testnet deploy.

## What

**1. Env-var split (backwards-compatible)**

- `SUI_NETWORK` stays = chain_id. Used at the chain_id sites only (renamed in-line to `CHAIN_ID` for clarity in `register.yml:85-95`).
- New `TOOLS_NAMESPACE` carries the deploy namespace. Every namespace-role site rewrites:
  ```diff
  - NETWORK="${{ vars.SUI_NETWORK }}"
  + NETWORK="${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}"
  ```
- Existing testnet/mainnet envs don't set `TOOLS_NAMESPACE` → falls back to `SUI_NETWORK` → byte-identical behavior.

**2. `allowed_leaders_subdir` injection in prepare.yml**

tf-nexus-tools' default mount-path derivation is `${NEXUS_TAG}/nexus-${network}-${major.minor.short}`, which works for v0.x (`nexus-testnet-v0-8`) but breaks at v2 because upstream uses the full RC suffix as the namespace dir name (`nexus-testnet-v2-0-rc-1`).

When `TOOLS_NAMESPACE` is set and differs from `SUI_NETWORK`, prepare.yml writes an explicit `allowed_leaders_subdir=${NEXUS_TAG}/${TOOLS_NAMESPACE}` into the per-tool blob. tf-nexus-tools already honors that override field (added during the static-tools migration); existing testnet/mainnet blobs continue to fall through to the v0.x derivation.

**3. New `nexus-testnet-v2-0-rc-1` deploy track in ci.yml**

Mechanical extension of the existing tag-driven model:
- `workflow_dispatch.inputs.target-env` enum: add `nexus-testnet-v2-0-rc-1`
- `push.branches`: add `iterate/nexus-testnet-v2-0-rc-1/**`
- `push.tags`: add `nexus-testnet-v2-0-rc-1-*`
- `concurrency` group: add `chain-nexus-testnet-v2-0-rc-1` arm
- `target-ref` ternary on `deploy`, `prepare`, `register` (3 places): add v2 tag + iterate arms returning `'nexus-testnet-v2-0-rc-1'`
- `environment` ternary in `deploy.yml`, `prepare.yml`, `register.yml`, `readiness.yml`: 3-way returning `'nexus-testnet-v2-0-rc-1'` for that target-ref

Naming convention: tag prefix mirrors the namespace exactly (`nexus-testnet-v2-0-rc-1-*` → env `nexus-testnet-v2-0-rc-1`). Long but explicit and extends naturally to `nexus-mainnet-v2-0-rc-1-*` if v2 ever lands on mainnet RC.

## Activation steps (not in this PR)

1. Create GitHub environment `nexus-testnet-v2-0-rc-1` with vars:
   - `SUI_NETWORK=testnet`
   - `TOOLS_NAMESPACE=nexus-testnet-v2-0-rc-1`
   - `NEXUS_TAG=v2.0.0-rc.1`
   - `NEXT_PUBLIC_SUI_RPC_URL=<testnet RPC>`
   - `GCP_PROJECT_ID`, `GCP_PROJECT_NUMBER`, `GCP_INFRA_PROJECT_ID`, `GCP_INFRA_PROJECT_NUMBER` (same as testnet)
   - `SUI_CHANNEL`, `SUI_CACHE_VERSION` (inherit unless v2 needs newer sui CLI)
   - `BLOCKED_TOOLS` (start with same value as testnet — `http` blocked for SSRF — adjust as needed)
   - secret `SUI_DEPLOYER_PK` (fresh deployer wallet, do not reuse testnet's)
2. tf-talus-nexus-v2 PR #16 applied → namespace running, `objects.testnet.toml` published under `v2.0.0-rc.1/` prefix in `production-talus-sui-objects`, allowed-leaders at `production-talus-sui-packages/v2.0.0-rc.1/nexus-testnet-v2-0-rc-1/allowed-leaders.json`.
3. tf-nexus-tools: add `"nexus-testnet-v2-0-rc-1"` to the `networks` list in `locals_tools.tf:44` (separate PR after this lands).
4. Push first `nexus-testnet-v2-0-rc-1-<date>` tag from main. Observe.

## Test plan

- [x] All 5 workflow YAMLs parse cleanly
- [x] `jq` conditional-merge expression for `allowed_leaders_subdir` verified locally (empty → omits key; set → emits key)
- [ ] PR CI dry-run passes (workflow validation only, no chain ops on PR)
- [ ] After activation: push `iterate/nexus-testnet-v2-0-rc-1/test1` branch, observe the full pipeline runs against the new env without touching testnet/mainnet GCS prefixes
- [ ] Cut `nexus-testnet-v2-0-rc-1-2026-...` tag, observe register lands on `nexus-testnet-v2-0-rc-1` namespace and Cloud Run services come up at `nexus-testnet-v2-0-rc-1-<tool>-v<version>.tools.internal`

## Risk

testnet/mainnet behavior:
- All namespace-role sites read `${{ vars.TOOLS_NAMESPACE || vars.SUI_NETWORK }}`. With `TOOLS_NAMESPACE` unset on existing envs, the rendered string is identical to before.
- chain_id-role sites (objects.toml URL + local nexus config) read `${{ vars.SUI_NETWORK }}` — unchanged.
- `allowed_leaders_subdir` injection only fires when `vars.TOOLS_NAMESPACE` is set AND different from `vars.SUI_NETWORK` — never fires on existing envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
